### PR TITLE
Properly refresh the displayed files in the tree when filters are enabled and the file state changes

### DIFF
--- a/Source/GitHubTools/Private/GitHubToolsTypes.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsTypes.cpp
@@ -234,6 +234,7 @@ bool FGithubToolsPullRequestFileInfos::IsUAsset() const
 void FGithubToolsPullRequestFileInfos::AddReview( const FGithubToolsPullRequestReviewThreadInfosPtr & review_thread_infos )
 {
     Reviews.Add( review_thread_infos );
+    review_thread_infos->ParentFileInfos = AsShared();
 
     if ( !review_thread_infos->bIsResolved )
     {
@@ -241,6 +242,20 @@ void FGithubToolsPullRequestFileInfos::AddReview( const FGithubToolsPullRequestR
     }
 
     OnDataChanged.Broadcast();
+}
+
+void FGithubToolsPullRequestFileInfos::RefreshResolvedConversations()
+{
+    const auto old_value = bHasUnresolvedConversations;
+
+    bHasUnresolvedConversations = Reviews.FindByPredicate( []( const FGithubToolsPullRequestReviewThreadInfosPtr & review_thread_infos ) {
+        return !review_thread_infos->bIsResolved;
+    } ) != nullptr;
+
+    if ( old_value != bHasUnresolvedConversations )
+    {
+        OnDataChanged.Broadcast();
+    }
 }
 
 FGithubToolsPullRequestReviewThreadInfos::FGithubToolsPullRequestReviewThreadInfos( const TSharedRef< FJsonObject > & json_object ) :
@@ -322,13 +337,16 @@ void FGithubToolsPullRequestInfos::SetFiles( const TArray< FGithubToolsPullReque
             file->Patch = ( *patch )->Patch;
         }
 
-        file->Reviews = reviews.FilterByPredicate( [ & ]( const FGithubToolsPullRequestReviewThreadInfosPtr & review_infos ) {
+        auto file_reviews = reviews.FilterByPredicate( [ & ]( const FGithubToolsPullRequestReviewThreadInfosPtr & review_infos ) {
             return review_infos->FileName == file->Path;
         } );
 
-        file->bHasUnresolvedConversations = file->Reviews.FindByPredicate( []( auto review ) {
-            return !review->bIsResolved;
-        } ) != nullptr;
+        for ( auto file_review : file_reviews )
+        {
+            file->AddReview( file_review );
+        }
+
+        file->RefreshResolvedConversations();
 
         FileInfos.Add( file );
     }

--- a/Source/GitHubTools/Private/GitHubToolsTypes.h
+++ b/Source/GitHubTools/Private/GitHubToolsTypes.h
@@ -115,18 +115,20 @@ struct FGithubToolsPullRequestReviewThreadInfos
     int Line;
     TArray< FGithubToolsPullRequestCommentPtr > Comments;
     int PRNumber;
+    TSharedPtr< struct FGithubToolsPullRequestFileInfos > ParentFileInfos;
 };
 
 typedef TSharedPtr< FGithubToolsPullRequestReviewThreadInfos > FGithubToolsPullRequestReviewThreadInfosPtr;
 
-struct FGithubToolsPullRequestFileInfos
+struct FGithubToolsPullRequestFileInfos : TSharedFromThis< FGithubToolsPullRequestFileInfos >
 {
     FGithubToolsPullRequestFileInfos() = default;
     FGithubToolsPullRequestFileInfos( const FString & path, const FString & change_type, const FString & viewed_state );
 
     void UpdateViewedState( EGitHubToolsFileViewedState new_viewed_state );
     bool IsUAsset() const;
-    void AddReview( const FGithubToolsPullRequestReviewThreadInfosPtr & review_thread_infos );
+    void AddReview( const FGithubToolsPullRequestReviewThreadInfosPtr& review_thread_infos );
+    void RefreshResolvedConversations();
 
     FGitHubToolsOnDataChanged OnDataChanged;
 

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsFileInfosRow.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsFileInfosRow.cpp
@@ -19,9 +19,9 @@ void SGitHubToolsFileInfosRow::Construct( const FArguments & arguments, const TS
 
     if ( TreeItem->FileInfos != nullptr )
     {
-        // TreeItem->FileInfos->OnDataChanged.AddSPLambda( this, [ & ]() {
-        //     Invalidate( EInvalidateWidgetReason::LayoutAndVolatility );
-        // } );
+         TreeItem->FileInfos->OnDataChanged.AddSPLambda( this, [ & ]() {
+            OnFileInfosStateChanged.ExecuteIfBound( TreeItem->FileInfos );
+         } );
 
         STableRow< FGitHubToolsFileInfosTreeItemPtr >::Construct(
             STableRow< FGitHubToolsFileInfosTreeItemPtr >::FArguments()

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfos.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfos.cpp
@@ -291,12 +291,12 @@ void SGitHubToolsPRInfos::OnShouldRebuildTree() const
 
 void SGitHubToolsPRInfos::OnFileInfosStateChanged( FGithubToolsPullRequestFileInfosPtr /*file_infos*/ )
 {
-    OnShouldRebuildTree();
+    OnTreeViewFiltersChanged();
 }
 
 void SGitHubToolsPRInfos::OnMultipleFileInfosStateChanged( const TArray< FGithubToolsPullRequestFileInfosPtr > & /*file_infos*/ )
 {
-    OnShouldRebuildTree();
+    OnTreeViewFiltersChanged();
 }
 
 void SGitHubToolsPRInfos::OnTreeViewFiltersChanged()

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewThreadTableRow.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewThreadTableRow.cpp
@@ -110,6 +110,7 @@ FReply SGitHubToolsPRReviewThreadTableRow::OnResolveConversationClicked()
             }
 
             ThreadInfos->bIsResolved = true;
+            ThreadInfos->ParentFileInfos->RefreshResolvedConversations();
         } );
 
     return FReply::Handled();


### PR DESCRIPTION
When filters are applied on the file list and the file state changes then the file list is refreshed again

Fixes #17