### PR TITLE
fix paginated requests

### DIFF
--- a/Source/GitHubTools/Private/GitHubToolsGitUtils.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsGitUtils.cpp
@@ -206,9 +206,9 @@ namespace GitHubToolsUtils
 
                 FGitHubToolsModule::Get()
                     .GetRequestManager()
-                    .SendRequest< FGitHubToolsHttpRequest_PR_GetFilePatches >( pr_number )
-                    .Then( [ &, files = MoveTemp( files ), pr_number ]( const TFuture< FGitHubToolsHttpRequest_PR_GetFilePatches > & file_patches ) {
-                        auto patches = file_patches.Get().GetResult().GetValue();
+                    .SendPaginatedRequest< FGitHubToolsHttpRequest_PR_GetFilePatches >( pr_number )
+                    .Then( [ &, files = MoveTemp( files ), pr_number ]( TFuture< TArray< FGithubToolsPullRequestFilePatchPtr > > file_patches ) {
+                        auto patches = file_patches.Get();
 
                         FGitHubToolsModule::Get()
                             .GetRequestManager()

--- a/Source/GitHubTools/Private/GitHubToolsGitUtils.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsGitUtils.cpp
@@ -553,6 +553,24 @@ namespace GitHubToolsUtils
 
         return true;
     }
+
+    bool IsUAsset( const FString & file_name )
+    {
+        static const FString UAssetExtensions[] = {
+            TEXT( ".uasset" ),
+            TEXT( ".umap" )
+        };
+
+        for ( const auto & extension : UAssetExtensions )
+        {
+            if ( file_name.EndsWith( extension ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitHubTools/Private/GitHubToolsGitUtils.h
+++ b/Source/GitHubTools/Private/GitHubToolsGitUtils.h
@@ -22,4 +22,5 @@ namespace GitHubToolsUtils
     void GetModifiedFiles( TArray< FString > & package_names );
     bool RevertFiles();
     bool SwitchGitBranch( const FString & branch_name );
+    bool IsUAsset( const FString & file_name );
 }

--- a/Source/GitHubTools/Private/GitHubToolsHttpRequestManager.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsHttpRequestManager.cpp
@@ -139,8 +139,6 @@ TFuture< typename TRequest::ResponseType > FGitHubToolsHttpRequestManager::SendP
             {
                 page_index++;
             }
-
-            // cursor = request_future_result.GetEndCursor();
         }
     } );
 }

--- a/Source/GitHubTools/Private/GitHubToolsHttpRequestManager.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsHttpRequestManager.cpp
@@ -2,8 +2,8 @@
 
 #include "Async/Async.h"
 #include "GitHubTools.h"
+#include "GitHubToolsHttpRequestsTypes.h"
 #include "GitHubToolsSettings.h"
-#include "GitHubToolsHelpers.h"
 #include "HttpModule.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -95,15 +95,20 @@ TFuture< typename TRequest::ResponseType > FGitHubToolsHttpRequestManager::SendP
 
     return Async( EAsyncExecution::TaskGraph, [ args_tuple = MoveTemp( args_tuple ) ]() mutable {
 #endif
-    
         FString cursor;
+        int page_index = 1;
         TResult result;
 
         while ( true )
         {
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
             typedef TGitHubToolsHttpRequestWrapper< TRequest > HttpRequestType;
-            auto request = MakeShared< HttpRequestType >( args..., cursor );
+            auto request = MakeShared< HttpRequestType >( args..., [ & ]() {
+                if constexpr ( TRequestTraits< TRequest >::IsGraphQL )
+                    return cursor;
+                else
+                    return page_index;
+            }() );
 #else
             auto request = MakeRequestWithTuple< TRequest >( args_tuple, cursor );
 #endif
@@ -126,7 +131,16 @@ TFuture< typename TRequest::ResponseType > FGitHubToolsHttpRequestManager::SendP
                 return result;
             }
 
-            cursor = request_future_result.GetEndCursor();
+            if constexpr ( TRequestTraits< TRequest >::IsGraphQL )
+            {
+                cursor = request_future_result.GetEndCursor();
+            }
+            else if constexpr ( TRequestTraits< TRequest >::IsRest )
+            {
+                page_index++;
+            }
+
+            // cursor = request_future_result.GetEndCursor();
         }
     } );
 }

--- a/Source/GitHubTools/Private/GitHubToolsHttpRequestsTypes.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsHttpRequestsTypes.cpp
@@ -189,3 +189,39 @@ FString FGitHubToolsHttpRequestRest< TResultType >::GetURL() const
 
     return *url_string_builder;
 }
+
+template < typename TResultType >
+FGitHubToolsHttpRequestRestQueryWithPagination< TResultType >::FGitHubToolsHttpRequestRestQueryWithPagination( const int page_index ) :
+    PageIndex( page_index ),
+    bHasNextPage( false )
+{
+}
+
+template < typename TResultType >
+void FGitHubToolsHttpRequestRestQueryWithPagination< TResultType >::ProcessResponse( const FHttpResponsePtr & response_ptr )
+{
+    for ( const auto & header : response_ptr->GetAllHeaders() )
+    {
+        if ( !header.StartsWith( TEXT( "Link" ) ) )
+        {
+            continue;
+        }
+        if ( header.Contains( TEXT( "rel=\"next\"" ) ) )
+        {
+            bHasNextPage = true;
+            break;
+        }
+    }
+
+    FGitHubToolsHttpRequestRestQuery< TResultType >::ProcessResponse( response_ptr );
+}
+
+template < typename TResultType >
+FString FGitHubToolsHttpRequestRestQueryWithPagination< TResultType >::GetURL() const
+{
+    TStringBuilder< 256 > url_string_builder;
+    url_string_builder.Append( FGitHubToolsHttpRequestRestQuery< TResultType >::GetURL() );
+    url_string_builder.Append( FString::Printf( TEXT( "?per_page=100&page=%i" ), PageIndex ) );
+
+    return *url_string_builder;
+}

--- a/Source/GitHubTools/Private/GitHubToolsHttpRequestsTypes.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsHttpRequestsTypes.cpp
@@ -139,7 +139,7 @@ FString FGitHubToolsHttpRequestGraphQLQueryWithPagination< TResultType >::GetCur
 
     if ( !AfterCursor.IsEmpty() )
     {
-        string_builder << TEXT( ", after: \\\"" ) << AfterCursor << TEXT( "\\\"" );
+        string_builder << TEXT( ", after: \"" ) << AfterCursor << TEXT( "\"" );
     }
 
     return *string_builder;

--- a/Source/GitHubTools/Private/GitHubToolsHttpRequestsTypes.h
+++ b/Source/GitHubTools/Private/GitHubToolsHttpRequestsTypes.h
@@ -118,3 +118,31 @@ template < typename TResultType >
 class FGitHubToolsHttpRequestRestQuery : public FGitHubToolsHttpRequestRest< TResultType >
 {
 };
+
+template < typename TResultType >
+class FGitHubToolsHttpRequestRestQueryWithPagination : public FGitHubToolsHttpRequestRestQuery< TResultType >
+{
+public:
+    explicit FGitHubToolsHttpRequestRestQueryWithPagination( const int page_index = 1 );
+
+    bool HasNextPage() const
+    {
+        return bHasNextPage;
+    }
+
+    void ProcessResponse( const FHttpResponsePtr & response_ptr ) override;
+
+protected:
+    FString GetURL() const override;
+
+private:
+    int PageIndex;
+    bool bHasNextPage;
+};
+
+template < typename T >
+struct TRequestTraits
+{
+    static constexpr bool IsGraphQL = TIsDerivedFrom< T, FGitHubToolsHttpRequestGraphQL< typename T::ResponseType > >::IsDerived;
+    static constexpr bool IsRest = TIsDerivedFrom< T, FGitHubToolsHttpRequestRest< typename T::ResponseType > >::IsDerived;
+};

--- a/Source/GitHubTools/Private/GitHubToolsTypes.cpp
+++ b/Source/GitHubTools/Private/GitHubToolsTypes.cpp
@@ -228,7 +228,7 @@ void FGithubToolsPullRequestFileInfos::UpdateViewedState( EGitHubToolsFileViewed
 
 bool FGithubToolsPullRequestFileInfos::IsUAsset() const
 {
-    return Path.EndsWith( TEXT( ".uasset" ) );
+    return GitHubToolsUtils::IsUAsset( Path );
 }
 
 void FGithubToolsPullRequestFileInfos::AddReview( const FGithubToolsPullRequestReviewThreadInfosPtr & review_thread_infos )

--- a/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFilePatches.cpp
+++ b/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFilePatches.cpp
@@ -5,14 +5,15 @@
 
 #define LOCTEXT_NAMESPACE "GitHubTools.Requests"
 
-FGitHubToolsHttpRequest_PR_GetFilePatches::FGitHubToolsHttpRequest_PR_GetFilePatches( int pull_request_number ) :
+FGitHubToolsHttpRequest_PR_GetFilePatches::FGitHubToolsHttpRequest_PR_GetFilePatches( int pull_request_number, int page_index ) :
+    FGitHubToolsHttpRequestRestQueryWithPagination( page_index ),
     PullRequestNumber( pull_request_number )
 {
 }
 
 FString FGitHubToolsHttpRequest_PR_GetFilePatches::GetEndPoint() const
 {
-    return FString::Printf( TEXT( "pulls/%i/files?per_page=100" ), PullRequestNumber );
+    return FString::Printf( TEXT( "pulls/%i/files" ), PullRequestNumber );
 }
 
 void FGitHubToolsHttpRequest_PR_GetFilePatches::ParseResponseData( const FJsonValue & json_data )

--- a/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFilePatches.cpp
+++ b/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFilePatches.cpp
@@ -1,6 +1,7 @@
 #include "HttpRequests/GitHubToolsHttpRequest_PR_GetFilePatches.h"
 
 #include "Dom/JsonValue.h"
+#include "GitHubToolsGitUtils.h"
 #include "Serialization/JsonSerializer.h"
 
 #define LOCTEXT_NAMESPACE "GitHubTools.Requests"
@@ -27,6 +28,12 @@ void FGitHubToolsHttpRequest_PR_GetFilePatches::ParseResponseData( const FJsonVa
     {
         const auto object = array_object->AsObject();
         const auto file_name = object->GetStringField( TEXT( "filename" ) );
+
+        if ( GitHubToolsUtils::IsUAsset( file_name ) )
+        {
+            continue;
+        }
+
         const auto patch = object->GetStringField( TEXT( "patch" ) );
 
         patches.Add( MakeShared< FGithubToolsPullRequestFilePatch >( file_name, patch ) );

--- a/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFilePatches.h
+++ b/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFilePatches.h
@@ -3,12 +3,12 @@
 #include "GitHubToolsHttpRequestsTypes.h"
 #include "GitHubToolsTypes.h"
 
-class FGitHubToolsHttpRequest_PR_GetFilePatches final : public FGitHubToolsHttpRequestRestQuery< TArray< FGithubToolsPullRequestFilePatchPtr > >
+class FGitHubToolsHttpRequest_PR_GetFilePatches final : public FGitHubToolsHttpRequestRestQueryWithPagination< TArray< FGithubToolsPullRequestFilePatchPtr > >
 {
 public:
-    typedef TArray< bool > ResponseType;
+    typedef TArray< FGithubToolsPullRequestFilePatchPtr > ResponseType;
 
-    explicit FGitHubToolsHttpRequest_PR_GetFilePatches( int pull_request_number );
+    FGitHubToolsHttpRequest_PR_GetFilePatches( int pull_request_number, int page_index = 1 );
 
 protected:
     FString GetEndPoint() const override;

--- a/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFiles.cpp
+++ b/Source/GitHubTools/Private/HttpRequests/GitHubToolsHttpRequest_PR_GetFiles.cpp
@@ -1,7 +1,6 @@
 #include "GitHubToolsHttpRequest_PR_GetFiles.h"
 
 #include "Dom/JsonValue.h"
-#include "GitHubToolsSettings.h"
 #include "Serialization/JsonSerializer.h"
 
 #define LOCTEXT_NAMESPACE "GitHubTools.Requests"

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRFilesChanged.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRFilesChanged.cpp
@@ -236,7 +236,7 @@ EVisibility SGitHubToolsPRFilesChanged::GetItemRowVisibility( FGithubToolsPullRe
 
     if ( TreeViewFilters->bShowOnlyUAssets )
     {
-        if ( !file_infos->Path.EndsWith( TEXT( ".uasset" ) ) )
+        if ( !file_infos->IsUAsset() )
         {
             return EVisibility::Collapsed;
         }


### PR DESCRIPTION
- **Fixed issue when generating a GraphQL query with an After cursor**
- **Implemented pagination for the REST queries and updated GetPullRequestInfos to fetch all the file patches**
- **Created helper function to know if a file name points to a uasset or umap**
- **Don't store file patches for uasset files**
- **Use IsUAsset in SGitHubToolsPRFilesChanged::GetItemRowVisibility**

Fixes #60 
Fixes #61 
