### PR TITLE
Disable various parts of the UI when a PR is merged

### DIFF
--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsAssetActions.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsAssetActions.cpp
@@ -1,7 +1,5 @@
 #include "SGitHubToolsAssetActions.h"
 
-#include "Components/HorizontalBox.h"
-#include "RevisionControlStyle/RevisionControlStyle.h"
 #include "Textures/SlateIcon.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SButton.h"
@@ -21,7 +19,7 @@ void SGitHubToolsAssetActions::Construct( const FArguments & arguments )
     ChildSlot
         [ SNew( SHorizontalBox )
                 .IsEnabled_Lambda( [ & ]() {
-                    return AreAssetActionsEnabled.Execute();
+                    return AreAssetActionsEnabled.IsBound() ? AreAssetActionsEnabled.Execute() : true;
                 } ) +
             SHorizontalBox::Slot()
                 .AutoWidth()

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsFileInfosRow.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsFileInfosRow.cpp
@@ -48,16 +48,16 @@ void SGitHubToolsFileInfosRow::Construct( const FArguments & arguments, const TS
                                             return TreeItem->FileInfos->ConversationStatus == EGitHubFileConversationStatus::UnResolvedConversations ? EVisibility::Visible : EVisibility::Collapsed;
                                         } ) )
                                         .ToolTipText( LOCTEXT( "UnresolvedComments", "This file has unresolved comments" ) ) ] +
-                         SHorizontalBox::Slot()
-                             .AutoWidth()
-                             .HAlign( HAlign_Center )
-                             .VAlign( VAlign_Center )
-                                 [ SAssignNew( ReviewImage, SImage )
-                                         .Image( FCoreStyle::Get().GetBrush( "Symbols.Check" ) )
-                                         .Visibility( TAttribute< EVisibility >::Create( [ & ]() {
-                                             return TreeItem->FileInfos->ConversationStatus == EGitHubFileConversationStatus::AllConversationsResolved ? EVisibility::Visible : EVisibility::Collapsed;
-                                         } ) )
-                                         .ToolTipText( LOCTEXT( "AllResolvedComments", "All the comments on this file are resolved" ) ) ] +
+                        SHorizontalBox::Slot()
+                            .AutoWidth()
+                            .HAlign( HAlign_Center )
+                            .VAlign( VAlign_Center )
+                                [ SAssignNew( ReviewImage, SImage )
+                                        .Image( FCoreStyle::Get().GetBrush( "Symbols.Check" ) )
+                                        .Visibility( TAttribute< EVisibility >::Create( [ & ]() {
+                                            return TreeItem->FileInfos->ConversationStatus == EGitHubFileConversationStatus::AllConversationsResolved ? EVisibility::Visible : EVisibility::Collapsed;
+                                        } ) )
+                                        .ToolTipText( LOCTEXT( "AllResolvedComments", "All the comments on this file are resolved" ) ) ] +
                         SHorizontalBox::Slot()
                             .FillWidth( 1.0f )
                                 [ SNew( STextBlock )
@@ -65,7 +65,6 @@ void SGitHubToolsFileInfosRow::Construct( const FArguments & arguments, const TS
                         SHorizontalBox::Slot()
                             .AutoWidth()
                                 [ SNew( SGitHubToolsAssetActions )
-                                        .AreAssetActionsEnabled( this, &SGitHubToolsFileInfosRow::GetButtonContainerEnable )
                                         .IsOpenButtonEnabled( this, &SGitHubToolsFileInfosRow::IsOpenButtonEnabled )
                                         .IsDiffButtonEnabled( this, &SGitHubToolsFileInfosRow::IsDiffButtonEnabled )
                                         .IsMarkedAsViewedButtonEnabled( this, &SGitHubToolsFileInfosRow::IsMarkedAsViewedButtonEnabled )
@@ -169,7 +168,8 @@ FReply SGitHubToolsFileInfosRow::OnDiffAssetButtonClicked()
 
 bool SGitHubToolsFileInfosRow::IsMarkedAsViewedButtonEnabled() const
 {
-    return TreeItem->FileInfos->ViewedState != EGitHubToolsFileViewedState::Viewed;
+    return !PRInfos->bIsMerged &&
+           TreeItem->FileInfos->ViewedState != EGitHubToolsFileViewedState::Viewed;
 }
 
 bool SGitHubToolsFileInfosRow::IsOpenButtonEnabled() const
@@ -180,11 +180,6 @@ bool SGitHubToolsFileInfosRow::IsOpenButtonEnabled() const
 bool SGitHubToolsFileInfosRow::IsDiffButtonEnabled() const
 {
     return TreeItem->FileInfos->ChangedState == EGitHubToolsFileChangedState::Modified;
-}
-
-bool SGitHubToolsFileInfosRow::GetButtonContainerEnable() const
-{
-    return true;
 }
 
 void SGitHubToolsFileInfosRow::OnFileInfosDataChanged()

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsFileInfosRow.h
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsFileInfosRow.h
@@ -25,7 +25,6 @@ private:
     bool IsMarkedAsViewedButtonEnabled() const;
     bool IsOpenButtonEnabled() const;
     bool IsDiffButtonEnabled() const;
-    bool GetButtonContainerEnable() const;
     void OnFileInfosDataChanged();
 
     FGithubToolsPullRequestInfosPtr PRInfos;

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRFilesChanged.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRFilesChanged.cpp
@@ -95,7 +95,6 @@ void SGitHubToolsPRFilesChanged::Construct( const FArguments & arguments )
                     SSplitter::Slot()
                         [ SAssignNew( ReviewList, SGitHubToolsPRReviewList )
                                 .PRInfos( PRInfos )
-                                .Visibility( this, &SGitHubToolsPRFilesChanged::GetPRReviewListVisibility )
                                 .OnShouldRebuildFileTreeView( this, &SGitHubToolsPRFilesChanged::OnShouldRebuildTree ) ] ] ];
 
     ExpandAllTreeItems();
@@ -354,11 +353,6 @@ void SGitHubToolsPRFilesChanged::OnShouldRebuildTree() const
 {
     TreeView->RebuildList();
     TreeView->RequestListRefresh();
-}
-
-EVisibility SGitHubToolsPRFilesChanged::GetPRReviewListVisibility() const
-{
-    return /* !PRInfos->HasPendingReviews() ? */ EVisibility::Visible /* : EVisibility::Collapsed */;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRFilesChanged.h
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRFilesChanged.h
@@ -33,7 +33,6 @@ private:
     void OnFileInfosStateChanged( FGithubToolsPullRequestFileInfosPtr file_infos );
     void OnMultipleFileInfosStateChanged( const TArray< FGithubToolsPullRequestFileInfosPtr > & file_infos );
     void OnShouldRebuildTree() const;
-    EVisibility GetPRReviewListVisibility() const;
 
     FGithubToolsPullRequestInfosPtr PRInfos;
     TSharedPtr< STreeView< FGitHubToolsFileInfosTreeItemPtr > > TreeView;

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.cpp
@@ -69,6 +69,18 @@ void SGitHubToolsPRHeader::Construct( const FArguments & arguments )
                 .Padding( FMargin( 10 ) )
                     [ SNew( SVerticalBox ) +
                         SVerticalBox::Slot()
+                            .MinHeight( 50.0f )
+                            .VAlign( VAlign_Top )
+                                [ SNew( SBorder )
+                                        .Visibility( this, &SGitHubToolsPRHeader::GetMergedPRInfoVisibility )
+                                        .Padding( 10.0f )
+                                        .ColorAndOpacity( FLinearColor::Green )
+                                        .BorderBackgroundColor( FLinearColor::Green )
+                                            [ SNew( STextBlock )
+                                                    .Text( LOCTEXT( "AlreadyMerged", "This PR has been merged" ) )
+                                                    .Justification( ETextJustify::Type::Center )
+                                                    .Font( FAppStyle::GetFontStyle( "BoldFont" ) ) ] ] +
+                        SVerticalBox::Slot()
                             .AutoHeight()
                                 [ SNew( STextBlock )
                                         .Text( FText::FromString( FString::Printf( TEXT( "%s ( # %i )" ), *PRInfos->Title, PRInfos->Number ) ) )
@@ -323,6 +335,11 @@ int SGitHubToolsPRHeader::GetApprovalWidgetSwitchIndex() const
 EVisibility SGitHubToolsPRHeader::CanEnablePRButtons() const
 {
     return PRInfos->bIsMerged ? EVisibility::Collapsed : EVisibility::Visible;
+}
+
+EVisibility SGitHubToolsPRHeader::GetMergedPRInfoVisibility() const
+{
+    return !PRInfos->bIsMerged ? EVisibility::Collapsed : EVisibility::Visible;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.cpp
@@ -178,6 +178,7 @@ void SGitHubToolsPRHeader::Construct( const FArguments & arguments )
                                         .FillWidth( 1.0f )
                                         .Padding( 5.0f )
                                             [ SAssignNew( ApprovalWidgetSwitcher, SWidgetSwitcher )
+                                                    .Visibility( this, &SGitHubToolsPRHeader::CanEnablePRButtons )
                                                     .WidgetIndex( this, &SGitHubToolsPRHeader::GetApprovalWidgetSwitchIndex ) +
                                                 SWidgetSwitcher::Slot()
                                                     .HAlign( HAlign_Fill )
@@ -228,6 +229,7 @@ void SGitHubToolsPRHeader::Construct( const FArguments & arguments )
                                         .Padding( 5.0f )
                                             [ SNew( SButton )
                                                     .VAlign( VAlign_Center )
+                                                    .Visibility( this, &SGitHubToolsPRHeader::CanEnablePRButtons )
                                                     .ButtonColorAndOpacity( FLinearColor( 1.0f, 0.0f, 0.0f, 1.0f ) )
                                                     .Text( LOCTEXT( "MergePR", "Merge the PR" ) )
                                                     .OnClicked( this, &SGitHubToolsPRHeader::OnMergePRClicked ) ] ]
@@ -298,6 +300,7 @@ FReply SGitHubToolsPRHeader::OnMergePRClicked()
             .GetRequestManager()
             .SendRequest< FGitHubToolsHttpRequest_PR_Merge >( PRInfos->Id )
             .Then( [ & ]( const TFuture< FGitHubToolsHttpRequest_PR_Merge > & /*request_future*/ ) {
+                PRInfos->bIsMerged = true;
                 FGitHubToolsModule::Get().GetNotificationManager().RemoveModalNotification();
             } );
     }
@@ -315,6 +318,11 @@ EVisibility SGitHubToolsPRHeader::GetPendingReviewsVisibility() const
 int SGitHubToolsPRHeader::GetApprovalWidgetSwitchIndex() const
 {
     return PRInfos->IsApprovedByMe() ? 0 : 1;
+}
+
+EVisibility SGitHubToolsPRHeader::CanEnablePRButtons() const
+{
+    return PRInfos->bIsMerged ? EVisibility::Collapsed : EVisibility::Visible;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.h
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.h
@@ -27,6 +27,7 @@ private:
     EVisibility GetPendingReviewsVisibility() const;
     int GetApprovalWidgetSwitchIndex() const;
     EVisibility CanEnablePRButtons() const;
+    EVisibility GetMergedPRInfoVisibility() const;
 
     FGithubToolsPullRequestInfosPtr PRInfos;
     TSharedPtr< SButton > ApprovePRButton;

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.h
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRInfosHeader.h
@@ -26,6 +26,7 @@ private:
     FReply OnMergePRClicked();
     EVisibility GetPendingReviewsVisibility() const;
     int GetApprovalWidgetSwitchIndex() const;
+    EVisibility CanEnablePRButtons() const;
 
     FGithubToolsPullRequestInfosPtr PRInfos;
     TSharedPtr< SButton > ApprovePRButton;

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewList.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewList.cpp
@@ -45,7 +45,7 @@ void SGitHubToolsPRReviewList::Construct( const FArguments & arguments )
                                                             .HAlign( HAlign_Left )
                                                                 [ SNew( SButton )
                                                                         .Text( LOCTEXT( "CreateNewThread", "Create new thread" ) )
-                                                                        // .IsEnabled( PRInfos->CanCommentFiles() )
+                                                                        .IsEnabled( this, &SGitHubToolsPRReviewList::CanCreateNewThread )
                                                                         .OnClicked( this, &SGitHubToolsPRReviewList::OnCreateNewThreadButtonClicked ) ] +
                                                         SHorizontalBox::Slot()
                                                             .AutoWidth()
@@ -95,7 +95,7 @@ void SGitHubToolsPRReviewList::ShowFileReviews( const FGithubToolsPullRequestFil
     }
     else
     {
-        ReviewThreadsListView->RequestListRefresh();   
+        ReviewThreadsListView->RequestListRefresh();
     }
 
     WidgetSwitcher->SetActiveWidgetIndex( 0 );
@@ -151,6 +151,11 @@ void SGitHubToolsPRReviewList::OnFileInfosDataChanged()
     } );
 
     ReviewThreadsListView->RequestListRefresh();
+}
+
+bool SGitHubToolsPRReviewList::CanCreateNewThread() const
+{
+    return !PRInfos->bIsMerged;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewList.h
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewList.h
@@ -34,6 +34,7 @@ private:
     FReply OnCreateNewThreadButtonClicked();
     void ShowAddCommentWindow( const FGithubToolsPullRequestReviewThreadInfosPtr & thread_infos );
     void OnFileInfosDataChanged();
+    bool CanCreateNewThread() const;
 
     TWeakPtr< SWindow > ParentFrame;
     FGithubToolsPullRequestInfosPtr PRInfos;

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewThreadTableRow.cpp
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewThreadTableRow.cpp
@@ -59,7 +59,7 @@ void SGitHubToolsPRReviewThreadTableRow::Construct( const FArguments & arguments
                             [ SNew( SButton )
                                     .HAlign( EHorizontalAlignment::HAlign_Center )
                                     .ContentPadding( FMargin( 5.0f ) )
-                                    .IsEnabled( !ThreadInfos->bIsResolved )
+                                    .IsEnabled( this, &SGitHubToolsPRReviewThreadTableRow ::CanEnableButtons )
                                     .OnClicked( OnAddCommentButtonClicked )
                                     .Text( LOCTEXT( "ReviewThread_AddCommmentText", "Add Comment" ) ) ] +
                     SHorizontalBox::Slot()
@@ -69,7 +69,7 @@ void SGitHubToolsPRReviewThreadTableRow::Construct( const FArguments & arguments
                             [ SNew( SButton )
                                     .HAlign( EHorizontalAlignment::HAlign_Center )
                                     .ContentPadding( FMargin( 5.0f ) )
-                                    .IsEnabled( !ThreadInfos->bIsResolved )
+                                    .IsEnabled( this, &SGitHubToolsPRReviewThreadTableRow ::CanEnableButtons )
                                     .OnClicked( this, &SGitHubToolsPRReviewThreadTableRow::OnResolveConversationClicked )
                                     .Text( LOCTEXT( "ReviewThread_ResolveButtonText", "Resolve conversation" ) ) ] ];
     }
@@ -122,6 +122,12 @@ FReply SGitHubToolsPRReviewThreadTableRow::OnCollapsedButtonClicked()
 
     OwnerTable->RequestListRefresh();
     return FReply::Handled();
+}
+
+bool SGitHubToolsPRReviewThreadTableRow::CanEnableButtons() const
+{
+    return !ThreadInfos->ParentFileInfos->PRInfos->bIsMerged &&
+           !ThreadInfos->bIsResolved;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewThreadTableRow.h
+++ b/Source/GitHubTools/Private/Widgets/SGitHubToolsPRReviewThreadTableRow.h
@@ -23,6 +23,7 @@ private:
     FReply OnResolveConversationClicked();
     FText GetCollapsedButtonText() const;
     FReply OnCollapsedButtonClicked();
+    bool CanEnableButtons() const;
 
     FGithubToolsPullRequestReviewThreadInfosPtr ThreadInfos;
     TSharedPtr< SVerticalBox > CommentsPanel;


### PR DESCRIPTION
Disable buttons that update the status of a PR when a PR is merged.
Display an information message at the top of the window when a PR is merged

Fixes #68 